### PR TITLE
fix: upgrade ses to work with newest chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "resolutions-note": "work-around for https://github.com/Agoric/agoric-sdk/issues/8621",
   "resolutions": {
-    "ses": "0.18.8",
+    "ses": "1.3.0",
     "@endo/bundle-source": "2.5.2-upstream-rollup",
     "@endo/captp": "3.1.1",
     "@endo/compartment-mapper": "0.8.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,14 +37,14 @@
     "happy-dom": "^13.3.1",
     "prettier": "^3.2.4",
     "puppeteer": "^21.9.0",
-    "ses": "^0.18.8",
+    "ses": "^1.3.0",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vitest": "^1.2.1",
     "zustand": "^4.4.1"
   },
   "resolutions": {
-    "**/ses": "^0.18.8",
+    "**/ses": "^1.3.0",
     "**/@agoric/xsnap": "0.14.3-dev-9f085d3.0"
   },
   "prettier": {

--- a/ui/src/installSesLockdown.ts
+++ b/ui/src/installSesLockdown.ts
@@ -3,7 +3,6 @@ import '@endo/eventual-send/shim.js'; // adds support needed by E
 
 const consoleTaming = import.meta.env.DEV ? 'unsafe' : 'safe';
 
-// @ts-expect-error global
 lockdown({
   errorTaming: 'unsafe',
   overrideTaming: 'severe',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,10 +1522,10 @@
     "@endo/zip" "^0.2.31"
     ses "^0.18.4"
 
-"@endo/env-options@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@endo/env-options/-/env-options-0.1.4.tgz#e516bc3864f00b154944e444fb8996a9a0c23a45"
-  integrity sha512-Ol8ct0aW8VK1ZaqntnUJfrYT59P6Xn36XPbHzkqQhsYkpudKDn5ILYEwGmSO/Ff+XJjv/pReNI0lhOyyrDa9mg==
+"@endo/env-options@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@endo/env-options/-/env-options-1.1.1.tgz#eee630f8eff01580ec49e0dedcb1b6cef05d89a4"
+  integrity sha512-uCwlJ8Vkndx/VBBo36BdYHdxSoQPy7ZZpwyJNfv86Rh4B1IZfqzCRPf0u0mPgJdzOr7lShQey60SuYwoMSZ9Xg==
 
 "@endo/eslint-plugin@^0.5.2":
   version "0.5.2"
@@ -7153,12 +7153,12 @@ serialize-error@^7.0.1:
   dependencies:
     type-fest "^0.13.1"
 
-ses@0.18.8, ses@^0.18.4, ses@^0.18.5, ses@^0.18.8:
-  version "0.18.8"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.18.8.tgz#88036511ac3b3c07e4d82dd8cfc6e5f3788205b6"
-  integrity sha512-kOH1AhJc6gWDXKURKeU1w7iFUdImAegAljVvBg5EUBgNqjH4bxcEsGVUadVEPtA2PVRMyQp1fiSMDwEZkQNj1g==
+ses@1.3.0, ses@^0.18.4, ses@^0.18.5, ses@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-1.3.0.tgz#4de8a2e740e5ff9e3cdbc4fd4a3574075c493f40"
+  integrity sha512-TURVgXm/fs38N4iJfhU9NjUiNvnU7Z/G7gVjM17jD+nrChRzMmR57fbvAzbQeGCS8Cm0m1fBs0jYCqmU6GZ7Tg==
   dependencies:
-    "@endo/env-options" "^0.1.4"
+    "@endo/env-options" "^1.1.1"
 
 set-function-length@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
fixes https://github.com/Agoric/dapp-agoric-basics/issues/13

Tested `yarn build && yarn preview`, as well as `yarn dev` and `yarn test`, and the app loads and I can connect to the wallet in MacOS chrome v122.0.

Also tested `cd contract && yarn build` which worked.