### PR TITLE
fix: follow @agoric/dapp package naming convention

### DIFF
--- a/_agstate/agoric-servers/package.json
+++ b/_agstate/agoric-servers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dapp-agoric-basics-agservers",
+  "name": "agoric-basics-agservers",
   "version": "0.0.1",
   "description": "Agoric server instances for dapp-agoric-basics",
   "private": true,

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
   "$note": "@agoric/create-dapp@0.1.0 expects an api/package.json",
-  "name": "dapp-agoric-basics-api",
+  "name": "agoric-basics-api",
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dapp-agoric-basics",
+  "name": "agoric-basics",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "private": true,


### PR DESCRIPTION
avoid:

```
Error#1: demo2/contract/package.json: "name" must start with "dapp-agoric-basics"
```

to test:

```
yarn create @agoric/dapp --dapp-template dapp-agoric-basics --dapp-branch dc-pkg-name demo3
```
