### PR TITLE
chore: use latest instead of main tag for a3p

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   agd:
+    # cf. https://github.com/Agoric/agoric-3-proposals
     image: ghcr.io/agoric/agoric-3-proposals:latest
     platform: linux/amd64
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.5'
 
 services:
   agd:
-    # image publication is WIP
-    # cf. https://github.com/Agoric/agoric-3-proposals/issues/6
-    image: ghcr.io/agoric/agoric-3-proposals:main
+    image: ghcr.io/agoric/agoric-3-proposals:latest
     platform: linux/amd64
     ports:
       - 26656:26656


### PR DESCRIPTION
Now that https://github.com/Agoric/agoric-3-proposals/pull/99 is merged

This PR is inspired by https://github.com/Agoric/dapp-offer-up/pull/69