### PR TITLE
chore: dedup bundles; upgrade deps to agoric-upgrade-14

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -17,9 +17,11 @@
     "lint:fix": "eslint --fix '**/*.js'"
   },
   "devDependencies": {
-    "@agoric/deploy-script-support": "^0.10.4-u12.0",
+    "@agoric/deploy-script-support": "^0.10.4-u14.0",
     "@agoric/eslint-config": "dev",
-    "@endo/bundle-source": "^2.8.0",
+    "@agoric/smart-wallet": "0.5.4-u14.0",
+    "@agoric/vats": "0.15.2-u14.0",
+    "@agoric/xsnap": "0.14.3-u14.0",
     "@endo/eslint-plugin": "^0.5.2",
     "@endo/init": "^0.5.60",
     "@endo/promise-kit": "0.2.56",
@@ -45,8 +47,9 @@
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "@agoric/ertp": "^0.16.3-u12.0",
-    "@agoric/zoe": "^0.26.3-u12.0",
+    "@agoric/ertp": "^0.16.3-u14.0",
+    "@agoric/zoe": "^0.26.3-u14.0",
+    "@endo/bundle-source": "^2.8.0",
     "@endo/far": "^0.2.22",
     "@endo/marshal": "^0.8.9",
     "@endo/patterns": "^0.2.5"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
   ],
   "resolutions-note": "work-around for https://github.com/Agoric/agoric-sdk/issues/8621",
   "resolutions": {
-    "ses": "1.3.0",
+    "ses": "0.18.4",
+    "@agoric/assert": "0.6.1-u11wf.0",
+    "@agoric/ertp": "0.16.3-u14.0",
+    "@agoric/store": "0.9.3-u14.0",
+    "@agoric/xsnap": "0.14.3-u14.0",
+    "@agoric/vat-data": "0.5.3-u14.0",
     "@endo/bundle-source": "2.5.2-upstream-rollup",
     "@endo/captp": "3.1.1",
     "@endo/compartment-mapper": "0.8.4",
@@ -31,9 +36,7 @@
     "@endo/check-bundle": "0.2.18",
     "@endo/ses-ava": "0.2.40",
     "@endo/netstring": "0.3.26",
-    "@endo/stream-node": "0.2.26",
-    "@babel/code-frame": "7.18.6",
-    "@babel/highlight": "7.22.5"
+    "@endo/stream-node": "0.2.26"
   },
   "scripts": {
     "start:docker": "cd contract && docker compose up -d",


### PR DESCRIPTION
| Bundle | before | dedup'd |
|--------|--------|--------|
| postal-service | 1.609 MB (0.408 MB gzip'd) | 0.947 MB (0.257 MB gzip'd) |
| sell-concert-tickets | 2.413 MB (**0.607 MB** gzip'd) | 1.006 MB (0.270 MB gzip'd) |

more detail: https://github.com/Agoric/dapp-agoric-basics/issues/15#issuecomment-1984252258 and https://github.com/Agoric/dapp-agoric-basics/issues/15#issuecomment-1984432875