### PR TITLE
fix: swaparoo failed to deploy due to missing config.options.swaparooCommittee

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,4 +63,5 @@ jobs:
       - name: verify contracts started onchain
         run: |
           curl http://localhost:1317/agoric/vstorage/data/published.agoricNames.instance | grep sellConcertTickets
+          curl http://localhost:1317/agoric/vstorage/data/published.agoricNames.instance | grep swaparoo
           curl http://localhost:1317/agoric/vstorage/data/published.agoricNames.instance | grep postalService

--- a/contract/src/swaparoo.proposal.js
+++ b/contract/src/swaparoo.proposal.js
@@ -147,7 +147,12 @@ export const startSwapContract = async powers => {
   console.log(`${contractName} (re)started`);
 };
 
-export const main = (permittedPowers, config) =>
+export const main = (
+  permittedPowers,
+  config = {
+    options: Fail`missing options config`,
+  },
+) =>
   allValues({
     installation: installSwapContract(permittedPowers, config),
     committeeFacets: startSwaparooCommittee(permittedPowers, config),

--- a/contract/tools/rollup-plugin-core-eval.js
+++ b/contract/tools/rollup-plugin-core-eval.js
@@ -26,6 +26,19 @@ export const moduleToScript = () => ({
   },
 });
 
+export const configureOptions = ({ options }) => {
+  const pattern = new RegExp(`options: Fail.*`, 'g');
+  const replacement = `options: ${JSON.stringify(options)},`;
+  return {
+    name: 'configureOptions',
+    transform: async (code, _id) => {
+      const revised = code.replace(pattern, replacement);
+      if (revised === code) return null;
+      return { code: revised };
+    },
+  };
+};
+
 export const configureBundleID = ({ name, rootModule, cache }) => {
   const pattern = new RegExp(`bundleID\\b = Fail.*`, 'g');
   const bundleCacheP = makeNodeBundleCache(cache, {}, s => import(s));


### PR DESCRIPTION

symptoms were: no `swaparoo` in `published.agoricNames.instance`.

Diagnosis:
```
agd-1  | 2024-03-19T21:48:56.868Z SwingSet: vat: v1: CORE_EVAL failed: (TypeError#3)
agd-1  | 2024-03-19T21:48:56.868Z SwingSet: vat: v1: TypeError#3: startMyCommittee: cannot coerce undefined to object
agd-1  | 2024-03-19T21:48:56.868Z SwingSet: vat: v1: TypeError: startMyCommittee: cannot coerce undefined to object
agd-1  |  at startMyCommittee (#9254:290)
agd-1  |  at startMyCommittee (#9254:277)
agd-1  |  at main (#9254:475)
agd-1  |  at ()
```

treatment: supply `swaparooCommittee` options using a new rollup plugin
