### PR TITLE
docs: Updates to the description of dapp-agoric-basics in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This is a basic Agoric Dapp that contains three smart contracts `postal-service`
 
 ## Getting started
 
-Assuming all the required dependecies are already installed (including node, nvm, docker, Keplr - See [here](https://docs.agoric.com/guides/getting-started/) tutorial on how to install these dependecies.), here are the steps to run `dapp-agoric-basics`: 
+Make sure all the required dependecies are already installed (including node, nvm, docker, Keplr, and that your node version is set to `18.x.x` by running `nvm use 18.20.2`. See [a tutorial here](https://docs.agoric.com/guides/getting-started/) on how to install these dependecies.). Here are the steps to run `dapp-agoric-basics`: 
 - run `yarn install` in the `agoric-basics` directory, to install dependencies of the Dapp.
 - run `yarn start:docker` to start Agoric blockchain from the container.
-- run `yarn docker:logs` to to make sure blocks are being produced by viewing the Docker logs; once your logs ressemeble the following, stop the logs by pressing `ctrl+c`.
+- run `yarn docker:logs` to to make sure blocks are being produced by viewing the Docker logs; once your logs resemble the following, stop the logs by pressing `ctrl+c`.
 ```
 demo-agd-1  | 2023-12-27T04:08:06.384Z block-manager: block 1003 begin
 demo-agd-1  | 2023-12-27T04:08:06.386Z block-manager: block 1003 commit
@@ -17,7 +17,7 @@ demo-agd-1  | 2023-12-27T04:08:08.405Z block-manager: block 1005 begin
 demo-agd-1  | 2023-12-27T04:08:08.407Z block-manager: block 1005 commit
 ```
 - run `yarn start:contract` to start the contracts.
-- run `yarn start:ui` to start `sell-concert-tickets` contract UI.
+- run `yarn start:ui` to start `sell-concert-tickets` contract UI. You will need `vite` for UI to start properly. You can install `vite` by running `yarn add vite`.
 - open a browser and navigate to `localhost:5173` to interact with the contract via UI.
 
 To follow more detailed tutorial, go [here](https://docs.agoric.com/guides/getting-started/tutorial-dapp-agoric-basics.html).

--- a/README.md
+++ b/README.md
@@ -29,12 +29,5 @@ To perform unit tests:
 To perform end to end test
 -run the command `yarn test:e2e` in the root directory.
 
-## Contributing: Development, Testing
-
-The UI is a React app started with the [vite](https://vitejs.dev/) `react-ts` template.
-On top of that, we add
-
-- Watching [blockchain state queries](https://docs.agoric.com/guides/getting-started/contract-rpc.html#querying-vstorage)
-- [Signing and sending offers](https://docs.agoric.com/guides/getting-started/contract-rpc.html#signing-and-broadcasting-offers)
-
-See [CONTRIBUTING](./CONTRIBUTING.md) for more on testing.
+## Contributing
+See [CONTRIBUTING](./CONTRIBUTING.md) for more on contributions.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@ This is a basic Agoric Dapp that contains three smart contracts `postal-service`
 
 ## Getting started
 
-See [Your First Agoric Dapp](https://docs.agoric.com/guides/getting-started/) tutorial.
+Assuming all the required dependecies are already installed (including node, nvm, docker, Keplr - See [here](https://docs.agoric.com/guides/getting-started/) tutorial on how to install these dependecies.), here are the steps to run `dapp-agoric-basics`: 
+- run `yarn install` in the `agoric-basics` directory, to install dependencies of the Dapp.
+- run `yarn start:docker` to start Agoric blockchain from the container.
+- run `yarn docker:logs` to to make sure blocks are being produced by viewing the Docker logs; once your logs ressemeble the following, stop the logs by pressing `ctrl+c`.
+```
+demo-agd-1  | 2023-12-27T04:08:06.384Z block-manager: block 1003 begin
+demo-agd-1  | 2023-12-27T04:08:06.386Z block-manager: block 1003 commit
+demo-agd-1  | 2023-12-27T04:08:07.396Z block-manager: block 1004 begin
+demo-agd-1  | 2023-12-27T04:08:07.398Z block-manager: block 1004 commit
+demo-agd-1  | 2023-12-27T04:08:08.405Z block-manager: block 1005 begin
+demo-agd-1  | 2023-12-27T04:08:08.407Z block-manager: block 1005 commit
+```
+- run `yarn start:contract` to start the contracts.
+- run `yarn start:ui` to start `sell-concert-tickets` contract UI.
+- open a browser and navigate to `localhost:5173` to interact with the contract via UI.
+
+To follow more detailed tutorial, go [here](https://docs.agoric.com/guides/getting-started/tutorial-dapp-agoric-basics.html).
 
 ## Contributing: Development, Testing
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ demo-agd-1  | 2023-12-27T04:08:08.407Z block-manager: block 1005 commit
 
 To follow more detailed tutorial, go [here](https://docs.agoric.com/guides/getting-started/tutorial-dapp-agoric-basics.html).
 
+## Testing
+
+To perform unit tests:
+-run the command `yarn test` in the root directory.
+To perform end to end test
+-run the command `yarn test:e2e` in the root directory.
+
 ## Contributing: Development, Testing
 
 The UI is a React app started with the [vite](https://vitejs.dev/) `react-ts` template.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # Agoric Dapp Starter: Agoric Basics
 
-This is a simple app for the [Agoric smart contract platform](https://docs.agoric.com/).
-
-<img alt="Vite + React + Agoric page with Connect Wallet button"
-style="border: 1px solid" width="300"
-src="https://docs.agoric.com/assets/img/new_002_small2.2dfb7462.png" />
-
-The contract lets you make an offer to give a small amount of [IST](https://inter.trade/) in exchange for
-a few NFTs.
+This is a basic Agoric Dapp that contains three smart contracts `postal-service`, `sell-concert-tickets`, and `swaparoo` demonstrating different scenarios which can be implemented easily using Agoric SDK. There is also a UI for `sell-concert-tickets` contract that a user can use to buy three different types of concert tickets and pay through a wallet extension in the browser. 
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ demo-agd-1  | 2023-12-27T04:08:08.405Z block-manager: block 1005 begin
 demo-agd-1  | 2023-12-27T04:08:08.407Z block-manager: block 1005 commit
 ```
 - run `yarn start:contract` to start the contracts.
-- run `yarn start:ui` to start `sell-concert-tickets` contract UI. You will need `vite` for UI to start properly. You can install `vite` by running `yarn add vite`.
+- run `yarn start:ui` to start `sell-concert-tickets` contract UI.
 - open a browser and navigate to `localhost:5173` to interact with the contract via UI.
 
 To follow more detailed tutorial, go [here](https://docs.agoric.com/guides/getting-started/tutorial-dapp-agoric-basics.html).


### PR DESCRIPTION
Here is a summary of proposed changes.
- README.md does not contain appropriate description of `dapp-agoric-basic` that is being added now.
- Confusing link to the [image](https://docs.agoric.com/assets/img/new_002_small2.2dfb7462.png") is removed.
- Instructions to `install` and `start` contracts is added to the **getting-started** subsection. This is basically a summary of instructions provided in the [tutorial](https://docs.agoric.com/guides/getting-started/tutorial-dapp-agoric-basics.html).
- added a separate subsection for `Testing` with instructions to perform unit and end to end tests.
- Cleaned Contributing subsection and removed links that may confuse new devs.
